### PR TITLE
React 16 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshotter",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Snapshot testing for Tape",
   "main": "dist/snapshotter.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/cdlewis/snapshotter.git"
   },
   "dependencies": {
-    "enzyme-to-json": "^1.4.5",
+    "enzyme-to-json": "^3.1.3",
     "jest-diff": "^18.1.0",
     "jest-file-exists": "^17.0.0",
     "lodash": "^4.0.0",
@@ -32,15 +32,15 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
-    "enzyme": "^2.4.1",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
     "eslint": "^3.15.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
-    "react": "~15.4.0",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "~15.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "tape": "^4.0.0"
   },
   "snapshotter": {

--- a/test/snapshotter.js
+++ b/test/snapshotter.js
@@ -1,8 +1,11 @@
+import Adapter from 'enzyme-adapter-react-16'
 import React from 'react'
-import { shallow } from 'enzyme'
+import Enzyme from 'enzyme'
 import test from 'tape'
 import { expectedJestDiff } from './fixtures'
 import compareToSnapshot from '../src/snapshotter'
+
+Enzyme.configure({ adapter: new Adapter() })
 
 const TestClass = () => (
   <div>
@@ -12,7 +15,7 @@ const TestClass = () => (
 
 test('snapshotter detects changes', (assert) => {
   const mockTape = { fail: () => {} }
-  const shallowWrapper = shallow(<TestClass />)
+  const shallowWrapper = Enzyme.shallow(<TestClass />)
   compareToSnapshot(mockTape, shallowWrapper, 'TestClass', {
     write: (diff) => {
       assert.deepEqual(diff, expectedJestDiff)
@@ -22,7 +25,7 @@ test('snapshotter detects changes', (assert) => {
 })
 
 test('snapshotter handles multiple files', (assert) => {
-  const shallowWrapper = shallow(<TestClass />)
+  const shallowWrapper = Enzyme.shallow(<TestClass />)
   compareToSnapshot(assert, shallowWrapper, 'TestClass-Fixed')
   assert.end()
 })


### PR DESCRIPTION
Updates enzyme-to-json, enzyme, and React versions to unlock React 16 and enzyme 3 compatibility.

I tested to see if this was backwards compatible with a React 15.4, React Native 0.42.3 environment and unfortunately it doesn't seem like it, maybe due to enzyme-to-json not being able to render out a non React 16 component. Thus, the major version bump to signify that this is a breaking change.

I did test within a React 16 and enzyme 3 environment and everything worked fine.