### PR TITLE
Pin enzyme-to-json version, set noKey to true to prevent keys from being written

### DIFF
--- a/dist/snapshotter.js
+++ b/dist/snapshotter.js
@@ -52,7 +52,7 @@ var maybeUpdateSnapshot = function maybeUpdateSnapshot(snapshotPath, relativeSna
 module.exports = function (assert, component, id) {
   var outputBuffer = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : _process2.default.stdout;
 
-  var serialisedComponent = JSON.parse(stringify((0, _enzymeToJson.shallowToJson)(component)));
+  var serialisedComponent = JSON.parse(stringify((0, _enzymeToJson.shallowToJson)(component, { noKey: true })));
 
   var _getSnapshotPath = (0, _getSnapshotPath3.default)(id),
       snapshotPath = _getSnapshotPath.snapshotPath,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshotter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Snapshot testing for Tape",
   "main": "dist/snapshotter.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/cdlewis/snapshotter.git"
   },
   "dependencies": {
-    "enzyme-to-json": "^3.1.3",
+    "enzyme-to-json": "3.1.3",
     "jest-diff": "^18.1.0",
     "jest-file-exists": "^17.0.0",
     "lodash": "^4.0.0",

--- a/src/snapshotter.js
+++ b/src/snapshotter.js
@@ -34,7 +34,7 @@ const maybeUpdateSnapshot = (snapshotPath, relativeSnapshotPath, component) => {
 }
 
 module.exports = (assert, component, id, outputBuffer = process.stdout) => {
-  const serialisedComponent = JSON.parse(stringify(shallowToJson(component)))
+  const serialisedComponent = JSON.parse(stringify(shallowToJson(component, { noKey: true })))
   const { snapshotPath, relativeSnapshotPath } = getSnapshotPath(id)
 
   try {


### PR DESCRIPTION
1. `enzyme-to-json` introduced a breaking change in their 3.2.0 release which caused an extra `node` property to be written out. To prevent compatibility issues with current clients using this, pin the dependency to the previous version to prevent this change from changing all current snapshot files.

2. Set `noKey` to true to prevent keys from being written out in snapshot files. Again, this is to preserve pre-snapshotter 2.0 client behavior. We could provide an optional argument to specify this though if you feel strongly about it.