### PR TITLE
Support snapshotting on arbitrary json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 # Snapshotter
 
 Snapshot testing is a compelling feature but sometimes it isn't possible to port
-large projects to tools like Jest. Snapshotter is designed to work within an
-existing Tape/Enzyme setup while providing some basic snapshot functionality.
+large projects to tools like Jest. Snapshotter is designed to be a drop-in replacement
+for Jest's `toMatchSnapshot` function. For backwards compatibility purposes, it
+includes built-in support for serialising Enzyme components.
 
 ![Screenshot](/screenshot.png?raw=true "Screenshot")
 

--- a/src/snapshotter.js
+++ b/src/snapshotter.js
@@ -5,6 +5,7 @@ import readlineSync from 'readline-sync';
 import { shallowToJson } from 'enzyme-to-json';
 import diff from 'jest-diff';
 import getSnapshotPath from './util/get-snapshot-path';
+import { isEnzymeWrapper } from 'enzyme-to-json/utils.js';
 
 const stringify = object =>
   JSON.stringify(
@@ -37,9 +38,9 @@ const maybeUpdateSnapshot = (snapshotPath, relativeSnapshotPath, component) => {
 };
 
 module.exports = (assert, component, id, outputBuffer = process.stdout) => {
-  const serialisedComponent = JSON.parse(
-    stringify(shallowToJson(component, { noKey: true }))
-  );
+  const serialisedComponent = isEnzymeWrapper(component)
+    ? JSON.parse(stringify(shallowToJson(component, { noKey: true })))
+    : component;
   const { snapshotPath, relativeSnapshotPath } = getSnapshotPath(id);
 
   try {

--- a/test/snapshots/ArbitraryJson.json
+++ b/test/snapshots/ArbitraryJson.json
@@ -1,0 +1,9 @@
+{
+  "reducers": {
+    "tasks": [
+      {
+        "name": "taskA"
+      }
+    ]
+  }
+}

--- a/test/snapshotter.js
+++ b/test/snapshotter.js
@@ -29,3 +29,13 @@ test('snapshotter handles multiple files', assert => {
   compareToSnapshot(assert, shallowWrapper, 'TestClass-Fixed');
   assert.end();
 });
+
+test('snapshotter handles arbitrary json files', assert => {
+  const arbitraryJson = {
+    reducers: {
+      tasks: [{ name: 'taskA' }]
+    }
+  };
+  compareToSnapshot(assert, arbitraryJson, 'ArbitraryJson');
+  assert.end();
+});


### PR DESCRIPTION
Snapshotter can be a useful framework for general change snapshotting without needing to be coupled to Enzyme.

Fixes https://github.com/cdlewis/snapshotter/issues/8